### PR TITLE
Fixed issue with uncropped image

### DIFF
--- a/netstandard/Examples/GenderClassification/Program.cs
+++ b/netstandard/Examples/GenderClassification/Program.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using UMapx.Core;
+using UMapx.Imaging;
 
 namespace GenderClassification
 {
@@ -32,7 +33,8 @@ namespace GenderClassification
                 {
                     Console.Write($"\t[Face #{i++}]: ");
 
-                    var output = faceGenderClassifier.Forward(bitmap);
+                    var cropped = BitmapTransform.Crop(bitmap, face);
+                    var output = faceGenderClassifier.Forward(cropped);
                     var max = Matrice.Max(output, out int gender);
                     var label = labels[gender];
 


### PR DESCRIPTION
The testing images did not contain multiple faces, so this issue did not arise. However, if an image with multiple faces was used, there would be a problem. This is because the original processing did not include a cropping process, resulting in the same output for all faces. I have fixed this issue by adding a cropping process to the code.