### PR TITLE
Update the Face Embeddings Classification example to be cross-platform

### DIFF
--- a/netstandard/Examples/FaceEmbeddingsClassification/FaceEmbeddingsClassification.csproj
+++ b/netstandard/Examples/FaceEmbeddingsClassification/FaceEmbeddingsClassification.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\FaceONNX\FaceONNX.csproj" />
-  </ItemGroup>
 
 	<ItemGroup>
 		<RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="FaceONNX" Version="3.0.1.3" />
+	  <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.1" />
+	  <PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.17.1" />
+	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
 	</ItemGroup>
 
 </Project>

--- a/netstandard/Examples/FaceEmbeddingsClassification/Program.cs
+++ b/netstandard/Examples/FaceEmbeddingsClassification/Program.cs
@@ -16,7 +16,8 @@ namespace FaceEmbeddingsClassification
         static void Main()
         {
             Console.WriteLine("FaceONNX: Face embeddings classification");
-            var fits = Directory.GetFiles(@"./images/fit", "*.*", SearchOption.AllDirectories);
+            var imagePath = Path.Combine(".", "images", "fit"); // Ensure x-plat path creation
+            var fits = Directory.GetFiles(imagePath, "*.*", SearchOption.AllDirectories);
             faceDetector = new FaceDetector();
             _faceLandmarksExtractor = new FaceLandmarksExtractor();
             _faceEmbedder = new FaceEmbedder();
@@ -31,7 +32,8 @@ namespace FaceEmbeddingsClassification
             }
 
             Console.WriteLine($"Embeddings count: {embeddings.Count}");
-            var scores = Directory.GetFiles(@"./images/score");
+            var scorePath = Path.Combine(".", "images", "score"); // Ensure x-plat path creation
+            var scores = Directory.GetFiles(scorePath);
             Console.WriteLine($"Processing {scores.Length} images");
             
             foreach (var score in scores)

--- a/netstandard/Examples/FaceEmbeddingsClassification/Program.cs
+++ b/netstandard/Examples/FaceEmbeddingsClassification/Program.cs
@@ -17,7 +17,7 @@ namespace FaceEmbeddingsClassification
         {
             Console.WriteLine("FaceONNX: Face embeddings classification");
             var imagePath = Path.Combine(".", "images", "fit"); // Ensure x-plat path creation
-            var fits = Directory.GetFiles(imagePath, "*.*", SearchOption.AllDirectories);
+            var fits = Directory.GetFiles(imagePath, "*.jpg", SearchOption.AllDirectories);
             faceDetector = new FaceDetector();
             _faceLandmarksExtractor = new FaceLandmarksExtractor();
             _faceEmbedder = new FaceEmbedder();
@@ -72,9 +72,9 @@ namespace FaceEmbeddingsClassification
                     var row = pixelAccessor.GetRowSpan(y);
                     for(var x = 0; x < pixelAccessor.Width; x++ )
                     {
-                        array[0][y, x] = row[x].R;
-                        array[1][y, x] = row[x].G;
-                        array[2][y, x] = row[x].B;
+                        array[0][y, x] = row[x].R / 255.0F;
+                        array[1][y, x] = row[x].G / 255.0F;
+                        array[2][y, x] = row[x].B / 255.0F;
                     }
                 }
             });


### PR DESCRIPTION
The existing example doesn't work on MacOS and won't work on Linux. To fix this:

- Replace `System.Drawing.Bitmap` with ImageSharp. 
- Replace the windows-specific file paths with `Path.Combine` so the paths will work on all platforms
- Replace the target (`.net8.0-windows` => `.net 8`)
- Add a reference to `Microsoft.ML.OnnxRuntime`

Love this library - it's *so* simple. Going to use it to replace the Azure Face detection that I used to have in https://github.com/Webreaper/Damselfly